### PR TITLE
Fix: Remove outdated --grpc-gateway-port reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+git add ./CHANGELOG.md
+
+clear
+x
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2945,7 +2945,7 @@ Please check that you are not using any of the removed flags in this section!
 - Tooling for prior testnet contracts has been removed. Any of the old testnet contracts with `drain()` function have
   been removed as well.
 - Toledo tesnet config is removed.
-- Removed --eth-api-port (beacon node). All APIs interactions have been moved to --grpc-gateway-port. See.
+- Removed --eth-api-port (beacon node). Updated API interactions in the latest release.
 
 ### Fixed
 


### PR DESCRIPTION
This PR fixes outdated references to --grpc-gateway-port.\n\nFixes #11451